### PR TITLE
Correcting messaging re: --withDir switch

### DIFF
--- a/JLECmd/Program.cs
+++ b/JLECmd/Program.cs
@@ -1690,7 +1690,7 @@ namespace JLECmd
                     {
                         Console.WriteLine();
                         Log.Warning(
-                            "  There are more items in the Directory ({DirectoryCount:N0}) than are contained in the DestList ({DestListCount:N0}). Use {Switch} to view/export them",autoDest.Directory.Count - 2,autoDest.DestListCount,"--WithDir");
+                            "  There are more items in the Directory ({DirectoryCount:N0}) than are contained in the DestList ({DestListCount:N0}). Use {Switch} to view/export them",autoDest.Directory.Count - 2,autoDest.DestListCount,"--withDir");
                     }
 
                     Console.WriteLine();


### PR DESCRIPTION
update message to correctly reflect the switch

Line 167 shows `--withDir`:

https://github.com/EricZimmerman/JLECmd/blob/057f782018a5067a79a2f3bf0ac2c502446b8019/JLECmd/Program.cs#L167

But line 1693 shows it as `--WithDir`, which does not work:

https://github.com/EricZimmerman/JLECmd/blob/057f782018a5067a79a2f3bf0ac2c502446b8019/JLECmd/Program.cs#L1693

Therefore, I'm updating `--WithDir` to `--withDir` on Line 1693 to be more in line with Line 167